### PR TITLE
feat/refactor: version 0

### DIFF
--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -124,7 +124,7 @@
     "\n",
     "misinformed_tweets = clean_text_list(misinformed_tweets)\n",
     "\n",
-    "prompts = tweet_prompt_generator.generate_prompts_for_tweets(misinformed_tweets)"
+    "prompts, stories, themes, similarity_scores = tweet_prompt_generator.generate_prompts_for_tweets(misinformed_tweets, clean_tweets=False)"
    ]
   },
   {

--- a/example_script.py
+++ b/example_script.py
@@ -58,7 +58,7 @@ def clean_text_list(text_list):
 
 misinformed_tweets = clean_text_list(misinformed_tweets)
 
-prompts = tweet_prompt_generator.generate_prompts_for_tweets(misinformed_tweets)
+prompts, stories, themes, similarity_scores = tweet_prompt_generator.generate_prompts_for_tweets(misinformed_tweets, clean_tweets=False)
 
 for prompt in prompts:
     print(prompt)

--- a/src/create_vdb.py
+++ b/src/create_vdb.py
@@ -3,9 +3,18 @@ from datasets import Dataset
 import faiss
 import torch
 import pandas as pd
+import logging
+
+log = logging.getLogger(__name__)
+
 
 class IndexTextEmbeddings:
     def __init__(self, model_name='sentence-transformers/multi-qa-mpnet-base-dot-v1', device='cpu'):
+        if torch.cuda.is_available():
+            log.info('Using GPU')
+            device = torch.device("cuda")
+        else:
+            log.info('Using CPU')
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, do_lower_case=True)
         self.model = AutoModel.from_pretrained(model_name).to(device)
         self.device = device

--- a/src/promptTemplate.txt
+++ b/src/promptTemplate.txt
@@ -1,7 +1,0 @@
-Query: {tweet}
-
-I have found several relevant pieces of information based on your query. Here they are:
-
-{retrieved_texts}
-
-Based on this information, [Specific question or task for the LLM].

--- a/src/prompt_generator.py
+++ b/src/prompt_generator.py
@@ -1,19 +1,23 @@
 import os
 from src.create_vdb import IndexTextEmbeddings
+import src.text_preprocess as tp
+
+
 
 class TweetPromptGenerator:
-    def __init__(self, dataset_with_index, model_name, project_root):
+    def __init__(self, dataset_with_index, model_name, project_root, template_path=None):
         self.dataset_with_index = dataset_with_index
         self.embeddings_generator = self._initialize_embeddings_generator(model_name)
-        self.prompt_template = self._load_prompt_template(project_root)
+        self.prompt_template = self._load_prompt_template(project_root, template_path)
     
     def _initialize_embeddings_generator(self, model_name):
         embedding_generator = IndexTextEmbeddings(model_name)
         return embedding_generator
     
-    def _load_prompt_template(self, project_root):
-        template_path = os.path.join(project_root, 
-                                     'python/RAG/src/promptTemplate.txt')
+    def _load_prompt_template(self, project_root, template_path):
+        if template_path is None:
+            template_path = os.path.join(project_root, 
+                                        'promptRAG/src/prompt_templates/promptTemplate.txt')
         with open(template_path, 'r') as file:
             prompt_template = file.read()
         return prompt_template
@@ -33,17 +37,21 @@ class TweetPromptGenerator:
             row_ids = samples['rowid']
             texts = samples['story']
             for score, row_id, text in zip(scores, row_ids, texts):
-                formatted_texts += f"Document ID {row_id} (Similarity Score: {score:.2f}):\n{text}\n\n"
-        return formatted_texts
+                # formatted_texts += f"Document ID {row_id} (Similarity Score: {score:.2f}):\n{text}\n\n"
+                formatted_texts += f"- {text}\n"
+        return formatted_texts, texts, samples['code'], scores
 
-    def generate_prompts_for_tweets(self, tweets, k=3):
+    def generate_prompts_for_tweets(self, tweets, k=3, clean_tweets=False):
         prompts = []
         for tweet in tweets:
             try:
+                original_tweet = tweet
+                if clean_tweets:
+                    tweets = tp.clean_text(tweet)
                 query_results = self.query_faiss_index([tweet], k=k)
-                formatted_texts = self.format_retrieved_texts(query_results)
-                complete_prompt = self.prompt_template.format(tweet=tweet, retrieved_texts=formatted_texts)
-                prompts.append(complete_prompt)
+                formatted_texts, texts, themes, scores = self.format_retrieved_texts(query_results)
+                complete_prompt = self.prompt_template.format(tweet=original_tweet, retrieved_texts=formatted_texts)
+                prompts.append((complete_prompt, texts, themes, scores))
             except Exception as e:
                 print(f"Error processing tweet: '{tweet}'. Error: {e}")
                 continue

--- a/src/prompt_templates/promptTemplate.txt
+++ b/src/prompt_templates/promptTemplate.txt
@@ -1,0 +1,5 @@
+Here are several examples of COVID misinformation:
+{retrieved_texts}
+
+Statement: << {tweet} >>
+[instruction]

--- a/src/prompt_templates/promptTemplate_mistral_onthefly.txt
+++ b/src/prompt_templates/promptTemplate_mistral_onthefly.txt
@@ -1,0 +1,8 @@
+
+[INST]You are tasked to classify whether a tweet contains misinformation or not. Use the following examples if it helps.
+
+Here are several examples of COVID misinformation:
+{retrieved_texts}
+Tweet: << {tweet} >>  
+
+[instruction][/INST]

--- a/src/text_preprocess.py
+++ b/src/text_preprocess.py
@@ -25,7 +25,7 @@ def clean_text(text):
     text = REM_NAN_WRD.sub('', text)
     text = str.lower(text)
     text = COVID.sub('covid_19', text)
-    text = COUNT_NUM.sub('COUNT', text)
+    # text = COUNT_NUM.sub('COUNT', text)
     return text
 
 


### PR DESCRIPTION
### State of module as used in the analysis/job ([here](https://github.com/ksgonser/NSF-Rapid-project/blob/main/python/tweet_classification/2024-04-11_classify_with_llm_plus_rag_HYAK_UWdata.py)) as of 2024/06 (version 0)
- `generate_prompts_for_tweets` returns prompt, stories, themes, similarity_scores.
- include text cleaning in `generate_prompts_for_tweets`
- include `template_path` in `_load_prompt_template`
- modified printout of `format_retrieved_texts`
- comment out text processing which caused issues
- add logger to confirm GPU usage
- update example nb/script
- reorganize prompt templates into folder